### PR TITLE
Add log levels

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,18 +46,18 @@ class _MyHomePageState extends State<MyHomePage> {
             children: <Widget>[
               TextButton(
                 onPressed: () async {
-                  await KingCache().storeLog('Call Json Place Holder API');
+                  await KingCache().storeLog('Call Json Place Holder API', level: LogLevel.info);
                   await KingCache.cacheViaRest(
                     'todos/1',
                     onSuccess: (data) =>
-                        KingCache().storeLog('Response: $data'),
+                        KingCache().storeLog('Response: $data', level: LogLevel.info),
                     onError: (data) => debugPrint('On Error: $data'),
                     apiResponse: (data) => debugPrint('Api Response: $data'),
                     isCacheHit: (isHit) => debugPrint('Is Cache Hit: $isHit'),
                     shouldUpdate: true,
                     expiryTime: DateTime.now().add(const Duration(hours: 1)),
                   );
-                  await KingCache().storeLog('Call Json Place Holder API');
+                  await KingCache().storeLog('Call Json Place Holder API', level: LogLevel.info);
                 },
                 child: const Text('Json Place Holder API'),
               ),

--- a/lib/src/cache_manager.dart
+++ b/lib/src/cache_manager.dart
@@ -11,5 +11,5 @@ abstract class ICacheManager {
   Future<void> removeCache(String key);
   Future<bool> hasCache(String key);
   Future<List<String>> getCacheKeys();
-  Future<void> storeLog(String log);
+  Future<void> storeLog(String log, {LogLevel level = LogLevel.info});
 }

--- a/lib/src/enums.dart
+++ b/lib/src/enums.dart
@@ -11,3 +11,11 @@ enum FilesTypes {
   /// The file associated with the enum value.
   final String file;
 }
+
+/// Enum representing different log levels.
+enum LogLevel {
+  debug,
+  info,
+  warning,
+  error,
+}

--- a/lib/src/log_methods.dart
+++ b/lib/src/log_methods.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 
 import '../king_cache.dart';
 
-Future<void> storeLogExec(String log) async {
+Future<void> storeLogExec(String log, {LogLevel level = LogLevel.info}) async {
   if (kIsWeb) {
     return;
   }
@@ -11,7 +11,8 @@ Future<void> storeLogExec(String log) async {
   final datePart = date.toString().split(' ')[0];
   final timePart =
       '${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}:${date.second.toString().padLeft(2, '0')}';
-  log = '$datePart $timePart: $log';
+  final logLevel = level.toString().split('.').last.toUpperCase();
+  log = '$datePart $timePart [$logLevel]: $log';
   if (file.existsSync()) {
     final data = file.readAsStringSync();
     if (data.isNotEmpty) {

--- a/test/logs_test.dart
+++ b/test/logs_test.dart
@@ -43,5 +43,18 @@ void main() {
       expect(file?.path.endsWith('.txt'), isTrue);
       await KingCache().clearLog;
     });
+
+    test('store & get logs with log levels', () async {
+      await KingCache().storeLog('Info log', level: LogLevel.info);
+      await KingCache().storeLog('Debug log', level: LogLevel.debug);
+      await KingCache().storeLog('Warning log', level: LogLevel.warning);
+      await KingCache().storeLog('Error log', level: LogLevel.error);
+      final logs = await KingCache().getLogs;
+      expect(logs.contains('INFO: Info log'), isTrue);
+      expect(logs.contains('DEBUG: Debug log'), isTrue);
+      expect(logs.contains('WARNING: Warning log'), isTrue);
+      expect(logs.contains('ERROR: Error log'), isTrue);
+      await KingCache().clearLog;
+    });
   });
 }


### PR DESCRIPTION
Related to #7

Add support for log levels in the codebase.

* **Enums**:
  - Add `LogLevel` enum in `lib/src/enums.dart` to define log levels.
* **Log Methods**:
  - Update `storeLogExec` method in `lib/src/log_methods.dart` to handle log levels.
* **Cache Manager**:
  - Update `storeLog` method in `lib/src/cache_manager.dart` to accept a log level parameter.
* **Example**:
  - Update `storeLog` calls in `example/lib/main.dart` to include log levels.
* **Tests**:
  - Add tests for log levels in `test/logs_test.dart`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/king-technologies/king_cache/issues/7?shareId=ce17dfe3-6421-495b-b5ef-1b35539b4f2f).